### PR TITLE
fix: rename token.py to tokens.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -129,6 +129,6 @@ dmypy.json
 .pyre/
 
 # config file
-token.py
+tokens.py
 
 test*

--- a/loabot.py
+++ b/loabot.py
@@ -1,7 +1,7 @@
 import os
 import sys
 sys.path.append(os.path.dirname(os.path.abspath(os.path.dirname(__file__))))
-import config
+import tokens
 from Ssal.auctioncalculator import *
 import discord
 from discord.ext import commands
@@ -39,4 +39,4 @@ async def qqr(ctx, price):  # ㅂㅂㄱ의 영어 타자
     await ctx.send(embed=embed)
 
 
-bot.run(config.token)
+bot.run(tokens.token)


### PR DESCRIPTION
Rename token.py to tokens.py to prevent interpreter to confuse library name for import.